### PR TITLE
Hotfix book build on GitHub Actions

### DIFF
--- a/scripts/build-book/build-book.sh
+++ b/scripts/build-book/build-book.sh
@@ -171,6 +171,23 @@ else
     info "  Skipping Mermaid rendering (mmdc not available)"
 fi
 
+# Remove Mermaid image references that were not rendered successfully so Pandoc
+# does not fail on missing SVG files in CI environments.
+if [[ -f "$COMBINED_MD" ]]; then
+    tmp_combined="${COMBINED_MD}.tmp"
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^!\[Diagram\]\((.*\.svg)\)$ ]]; then
+            svg_path="${BASH_REMATCH[1]}"
+            if [[ ! -f "$svg_path" ]]; then
+                warn "Removing unresolved Mermaid reference: $svg_path"
+                continue
+            fi
+        fi
+        printf '%s\n' "$line" >> "$tmp_combined"
+    done < "$COMBINED_MD"
+    mv "$tmp_combined" "$COMBINED_MD"
+fi
+
 # ---------------------------------------------------------------------------
 # Step 5: Build PDF
 # ---------------------------------------------------------------------------

--- a/scripts/build-book/build-book.sh
+++ b/scripts/build-book/build-book.sh
@@ -49,13 +49,27 @@ check_tool() {
     command -v "$1" &>/dev/null || die "'$1' is required but not found in PATH"
 }
 
+detect_imagemagick() {
+    if command -v magick &>/dev/null; then
+        echo "magick"
+        return
+    fi
+
+    if command -v convert &>/dev/null; then
+        echo "convert"
+        return
+    fi
+
+    die "ImageMagick is required but neither 'magick' nor 'convert' was found in PATH"
+}
+
 # ---------------------------------------------------------------------------
 # Pre-flight checks
 # ---------------------------------------------------------------------------
 info "Checking required tools..."
 check_tool python3
 check_tool pandoc
-check_tool magick
+IMAGEMAGICK_CMD="$(detect_imagemagick)"
 
 if [[ "$TARGET" == "all" || "$TARGET" == "pdf" ]]; then
     check_tool xelatex
@@ -98,7 +112,7 @@ while IFS= read -r -d '' webp_file; do
         continue
     fi
 
-    magick "$webp_file" "$png_path"
+    "$IMAGEMAGICK_CMD" "$webp_file" "$png_path"
     webp_count=$((webp_count + 1))
 done < <(find "$DOCS_DIR" -name '*.webp' -print0)
 


### PR DESCRIPTION
## Summary
- make the book build script work whether ImageMagick is exposed as 'magick' or 'convert'
- remove unresolved Mermaid SVG references from the generated combined markdown when Mermaid rendering fails on CI

## Why
The book pipeline merged into main, but GitHub-hosted runners still failed in two follow-up cases:
- some environments provide ImageMagick without the magick wrapper
- Mermaid CLI can fail to render in CI, which previously left broken SVG references that caused Pandoc to abort

This hotfix keeps the book build resilient on GitHub Actions without changing the intended output when rendering succeeds.

## Validation
- ./scripts/build-book/build-book.sh pdf
- local GitHub Actions simulation with act confirmed the build step succeeds
- manual GitHub Actions run on the updated branch passed: https://github.com/aucoop/Community-Network-Handbook/actions/runs/23998668076