### PR TITLE
Fix/open points

### DIFF
--- a/docs/3-Guide/Wireless-Mesh/1-Static-IP-Mesh/index.md
+++ b/docs/3-Guide/Wireless-Mesh/1-Static-IP-Mesh/index.md
@@ -1,12 +1,12 @@
-# OpenWrt 802.11s Wireless Mesh Setup
+# OpenWrt 802.11s Wireless Mesh Setup (Iteration 1 — Static IP)
 
-This guide walks you through configuring an 802.11s wireless mesh backhaul between two OpenWrt routers using the LuCI web interface, plus a shared 2.4 GHz access point for end users.
+This guide walks you through the **first iteration** of a wireless mesh deployment: configuring an 802.11s wireless mesh backhaul between two OpenWrt routers using the LuCI web interface, plus a shared 2.4 GHz access point for end users. Each satellite is assigned a unique static LAN IP by hand.
 
 This guide implements the concepts introduced in
-[Chapter 2.2 — Expanding Coverage](../../../2-Imaginary-Use-Case/2.2-Expanding-Coverage/index.md).
+[Chapter 2.2 — Expanding Coverage](../../../2-Imaginary-Use-Case/2.2-Expanding-Coverage/index.md), in particular [Wired vs Wireless](../../../2-Imaginary-Use-Case/2.2-Expanding-Coverage/2.2.3-Wired-vs-Wireless.md).
 
-!!! tip "Alternative: DHCP-based approach"
-    This guide uses static IP addresses for satellite routers. For an alternative approach using DHCP, see the [DHCP-Based Mesh guide](../2-DHCP-Mesh/index.md).
+!!! tip "Next iteration: DHCP-based mesh"
+    Once this static-IP mesh is up and running, the recommended next step is to follow the [DHCP-based Mesh guide](../2-DHCP-Mesh/index.md) to centralize IP management on the main router. The two guides are designed to be done in sequence — see the [Wireless Mesh overview](../index.md) for the full path.
 
 !!! note "Other mesh setups possible"
     This is not the only way to set up a wireless mesh with OpenWrt. This guide focuses on a simple, beginner-friendly setup using LuCI that is suitable for most community network use cases. It uses the 5 GHz band for the mesh backhaul and 2.4 GHz for the access point, but other configurations are possible depending on your hardware capabilities and coverage needs.
@@ -48,103 +48,100 @@ This guide implements the concepts introduced in
 
 ### 1. Set the LAN IP address
 
-Before anything else, each router needs a unique IP on your subnet so they do not conflict.
+Each router needs a unique IP on your subnet so they do not conflict.
 
-Go to **Network > Interfaces** and edit the **LAN** interface. Change the **IPv4 address** to fit your main subnet. For example, if the main router is `192.168.70.1`, set the secondary router to `192.168.70.3`.
+1. Go to **Network → Interfaces** and click **Edit** on the **LAN** interface.
+2. Change the **IPv4 address** to fit your main subnet. For example, if the main router is `192.168.70.1`, set the secondary router to `192.168.70.3`.
 
-![LuCI LAN interface showing the IPv4 address field set to a new IP](images/Wireless-Mesh-set-lan-ip.webp){ width="600" }
+    ![LuCI LAN interface showing the IPv4 address field set to a new IP](images/Wireless-Mesh-set-lan-ip.webp){ width="600" }
 
-Click **Save & Apply**. You will need to reconnect to the router using the new IP address.
+3. Click **Save & Apply**. You will need to reconnect to the router using the new IP address.
+4. On the **secondary router only**, set the **IPv4 gateway** to the main router's IP (e.g., `192.168.70.1`) in the same **LAN** interface edit screen.
+5. On the **secondary router only**, switch to the **Advanced Settings** tab and add the main router's IP (e.g., `192.168.70.1`) as a **custom DNS server**.
+6. Click **Save & Apply**. Reconnect to the router using the new IP address.
 
-On the **secondary router only**, also configure the gateway and DNS so the device itself can reach the internet for management tasks (package updates, NTP sync, etc.):
-
-1. In the same **LAN** interface edit screen, set the **IPv4 gateway** to the main router's IP (e.g., `192.168.70.1`).
-2. Switch to the **Advanced Settings** tab and add the main router's IP (e.g., `192.168.70.1`) as a **custom DNS server**.
-
-    ![LuCI LAN interface showing custom DNS server fields](images/Wireless-Mesh-set-dns.webp){ width="600" }
-
-Click **Save & Apply**. You will need to reconnect to the router using the new IP address.
+!!! info "Why configure gateway and DNS on the secondary router?"
+    The secondary router itself needs internet access for management tasks like package updates and NTP sync. Pointing its gateway and DNS to the main router gives it that connectivity.
 
 ### 2. Remove the default Wi-Fi package
 
 OpenWrt ships with `wpad-basic-mbedtls` (or a similar variant), which does not support 802.11s mesh. You must replace it with the mesh-capable version.
 
-Navigate to **System > Software** and click **Update lists** to refresh the package index.
+1. Navigate to **System → Software**.
+2. Click **Update lists** to refresh the package index.
+3. Filter for `wpad-basic`.
+4. Find your installed version (e.g., `wpad-basic-mbedtls`) and click **Remove**.
 
-Filter for `wpad-basic`. Find your installed version (e.g., `wpad-basic-mbedtls`) and click **Remove**.
-
-![LuCI Software page showing wpad-basic-mbedtls selected for removal](images/Wireless-Mesh-remove-wpad-basic.webp){ width="600" }
+    ![LuCI Software page showing wpad-basic-mbedtls selected for removal](images/Wireless-Mesh-remove-wpad-basic.webp){ width="600" }
 
 !!! warning "Wait for the removal to finish"
     Do not proceed until the removal completes. Installing the new package while the old one is still present can cause LuCI errors or a broken Wi-Fi stack.
 
 ### 3. Install the mesh-capable Wi-Fi package
 
-Still in **System > Software**, filter for `wpad-mesh`. Find the matching variant (e.g., `wpad-mesh-wolfssl`) and click **Install**.
+1. Still in **System → Software**, filter for `wpad-mesh`.
+2. Find the matching variant (e.g., `wpad-mesh-wolfssl`) and click **Install**.
 
-![LuCI Software page showing wpad-mesh-wolfssl ready to install](images/Wireless-Mesh-install-wpad-mesh.webp){ width="600" }
+    ![LuCI Software page showing wpad-mesh-wolfssl ready to install](images/Wireless-Mesh-install-wpad-mesh.webp){ width="600" }
 
-After installation completes, navigate to **System > Reboot** and restart the router. Repeat steps 1 through 3 on the second router before continuing.
+3. Navigate to **System → Reboot** and restart the router.
+4. Repeat steps 1 through 3 on the second router before continuing.
 
 !!! tip "Verify the package is active"
-    After rebooting, go back to **System > Software** and confirm that `wpad-mesh-wolfssl` (or your chosen variant) appears in the installed list and that `wpad-basic-*` is gone.
+    After rebooting, go back to **System → Software** and confirm that `wpad-mesh-wolfssl` (or your chosen variant) appears in the installed list and that `wpad-basic-*` is gone.
 
 ### 4. Disable DHCP on the secondary router
 
 The secondary router must act as a "dumb AP" so it does not hand out its own IP addresses or compete with the main router's DHCP server.
 
-On the **secondary router only**, go to **Network > Interfaces**, edit the **LAN** interface, and scroll down to the **DHCP Server** section. Check the box **Ignore interface** to disable DHCP on this device.
+1. On the **secondary router only**, go to **Network → Interfaces** and click **Edit** on the **LAN** interface.
+2. Scroll down to the **DHCP Server** section.
+3. Check the box **Ignore interface** to disable DHCP on this device.
 
-![LuCI DHCP Server section with the Ignore interface checkbox enabled](images/Wireless-Mesh-disable-dhcp.webp){ width="600" }
+    ![LuCI DHCP Server section with the Ignore interface checkbox enabled](images/Wireless-Mesh-disable-dhcp.webp){ width="600" }
 
-Click **Save & Apply**.
+4. Click **Save & Apply**.
 
-!!! note "Why disable DHCP?"
+!!! info "Why disable DHCP?"
     Two DHCP servers on the same network will hand out conflicting leases, causing intermittent connectivity for all clients. Only the main router should run DHCP.
 
 ### 5. Configure the 5 GHz mesh backhaul
 
 This is the wireless link that connects the two routers together. The settings must be **identical** on both devices.
 
-On each router, go to **Network > Wireless**. Find the radios (i.e. radio0, radio1) and remove any default Wi-Fi networks attached to it.
+1. On each router, go to **Network → Wireless**.
+2. Find the radios (e.g. `radio0`, `radio1`) and remove any default Wi-Fi networks attached to them.
 
-![LuCI Wireless page with the default 5 GHz network being removed](images/Wireless-Mesh-remove-default-wifi.webp){ width="600" }
+    ![LuCI Wireless page with the default 5 GHz network being removed](images/Wireless-Mesh-remove-default-wifi.webp){ width="600" }
 
-Click **Add** on the 5 GHz radio to create a new wireless interface.
+3. Click **Add** on the 5 GHz radio to create a new wireless interface.
 
-![LuCI showing the Add button on the 5 GHz radio](images/Wireless-Mesh-add-5ghz-interface.webp){ width="600" }
+    ![LuCI showing the Add button on the 5 GHz radio](images/Wireless-Mesh-add-5ghz-interface.webp){ width="600" }
 
-Configure the new interface with these settings:
+4. Configure the **Device Configuration** section:
 
-**Device Configuration:**
+    - **Channel**: A fixed channel (e.g., **44**). Do **not** use Auto.
+    - **Width**: **20 MHz** or **40 MHz**. Narrower channels penetrate walls better.
 
-| Setting   | Value                                                                 |
-|-----------|-----------------------------------------------------------------------|
-| Channel   | A fixed channel (e.g., **44**). Do **not** use Auto.                  |
-| Width     | **20 MHz** or **40 MHz**. Narrower channels penetrate walls better.   |
+5. Configure the **Interface Configuration** section:
 
-**Interface Configuration:**
+    - **Mode**: **802.11s**
+    - **Mesh ID**: `School_Backhaul` (must match exactly on both routers)
+    - **Network**: check the box for **lan**
 
-| Setting   | Value                                                     |
-|-----------|-----------------------------------------------------------|
-| Mode      | **802.11s**                                               |
-| Mesh ID   | `School_Backhaul` (must match exactly on both routers)    |
-| Network   | Check the box for **lan**                                 |
+    ![LuCI radio and interface configuration for the 5 GHz mesh backhaul](images/Wireless-Mesh-radio-configuration.webp){ width="600" }
 
-![LuCI radio and interface configuration for the 5 GHz mesh backhaul](images/Wireless-Mesh-radio-configuration.webp){ width="600" }
+6. Configure the **Wireless Security** section:
 
-**Wireless Security:**
+    - **Encryption**: **WPA3-SAE**
+    - **Key**: a strong password, identical on both routers
 
-| Setting    | Value                                                        |
-|------------|--------------------------------------------------------------|
-| Encryption | **WPA3-SAE**                                                 |
-| Key        | A strong password, identical on both routers                 |
+    ![LuCI wireless security configuration for the mesh interface](images/Wireless-Mesh-mesh-security.webp){ width="600" }
 
-![LuCI wireless security configuration for the mesh interface](images/Wireless-Mesh-mesh-security.webp){ width="600" }
+7. Click **Save & Apply** on both routers.
+8. Check the **Network → Wireless** page — a **Tx/Rx rate** appearing on the mesh interface and an entry under **Associated Stations** confirm the link is up.
 
-Click **Save & Apply** on both routers. Then check the **Network > Wireless** page -- a **Tx/Rx rate** appearing on the mesh interface and an entry under **Associated Stations** confirm the link is up.
-
-![LuCI Wireless page showing the mesh peer listed under Associated Stations](images/Wireless-Mesh-associated-stations.webp){ width="600" }
+    ![LuCI Wireless page showing the mesh peer listed under Associated Stations](images/Wireless-Mesh-associated-stations.webp){ width="600" }
 
 !!! tip "No link forming?"
     Double-check that the channel, mesh ID, encryption type, and key are identical on both routers. Also ensure both devices are within radio range and that no DFS channels are causing radar detection delays.
@@ -153,37 +150,31 @@ Click **Save & Apply** on both routers. Then check the **Network > Wireless** pa
 
 This is the Wi-Fi network that end users will connect to. Configure it on **both** routers so users can roam seamlessly between them.
 
-Go to **Network > Wireless**, find the **2.4 GHz radio**, and click **Add** (or **Edit** if a default network exists).
+1. Go to **Network → Wireless**.
+2. Find the **2.4 GHz radio** and click **Add** (or **Edit** if a default network exists).
+3. Configure the **Device Configuration** section:
 
-**Device Configuration:**
+    - **Channel**: **Auto**, or a fixed non-overlapping channel (**1**, **6**, or **11**)
+    - **Transmit Power**: Default or Medium (approximately 15–18 dBm)
 
-| Setting         | Value                                                              |
-|-----------------|--------------------------------------------------------------------|
-| Channel         | **Auto**, or a fixed non-overlapping channel (**1**, **6**, or **11**) |
-| Transmit Power  | Default or Medium (approximately 15--18 dBm)                      |
+4. Configure the **Interface Configuration** section:
 
-**Interface Configuration:**
+    - **Mode**: **Access Point**
+    - **ESSID**: `School_Student_WiFi`
+    - **Network**: check the box for **lan**
 
-| Setting   | Value                          |
-|-----------|--------------------------------|
-| Mode      | **Access Point**               |
-| ESSID     | `School_Student_WiFi`          |
-| Network   | Check the box for **lan**      |
+    ![LuCI 2.4 GHz interface configuration for the student access point](images/Wireless-Mesh-2ghz-ap-config.webp){ width="600" }
 
-![LuCI 2.4 GHz interface configuration for the student access point](images/Wireless-Mesh-2ghz-ap-config.webp){ width="600" }
+5. Configure the **Wireless Security** section:
 
-**Wireless Security:**
+    - **Encryption**: **WPA2-PSK** (best compatibility with older student devices)
+    - **Key**: the shared password for students
 
-| Setting    | Value                                                                     |
-|------------|---------------------------------------------------------------------------|
-| Encryption | **WPA2-PSK** (best compatibility with older student devices)              |
-| Key        | The shared password for students                                          |
+    ![LuCI 2.4 GHz wireless security settings](images/Wireless-Mesh-2ghz-ap-security.webp){ width="600" }
 
-![LuCI 2.4 GHz wireless security settings](images/Wireless-Mesh-2ghz-ap-security.webp){ width="600" }
+6. Click **Save & Apply**.
 
-Click **Save & Apply**.
-
-!!! note "Seamless roaming between access points"
+!!! info "Seamless roaming between access points"
     For users to move between coverage areas without re-entering the password, the **ESSID**, **Encryption**, and **Key** must be identical on the 2.4 GHz AP of all routers. Devices will automatically switch to the strongest available signal.
 
 ## References

--- a/docs/3-Guide/Wireless-Mesh/1-Static-IP-Mesh/index.md
+++ b/docs/3-Guide/Wireless-Mesh/1-Static-IP-Mesh/index.md
@@ -58,7 +58,7 @@ Each router needs a unique IP on your subnet so they do not conflict.
 3. Click **Save & Apply**. You will need to reconnect to the router using the new IP address.
 4. On the **secondary router only**, set the **IPv4 gateway** to the main router's IP (e.g., `192.168.70.1`) in the same **LAN** interface edit screen.
 5. On the **secondary router only**, switch to the **Advanced Settings** tab and add the main router's IP (e.g., `192.168.70.1`) as a **custom DNS server**.
-6. Click **Save & Apply**. Reconnect to the router using the new IP address.
+6. Click **Apply Unchecked** --> Red option. If you only click "Save & Apply" most probably the router will rollback the changes you've made. Reconnect to the router using the new IP address.
 
 !!! info "Why configure gateway and DNS on the secondary router?"
     The secondary router itself needs internet access for management tasks like package updates and NTP sync. Pointing its gateway and DNS to the main router gives it that connectivity.

--- a/docs/3-Guide/Wireless-Mesh/2-DHCP-Mesh/index.md
+++ b/docs/3-Guide/Wireless-Mesh/2-DHCP-Mesh/index.md
@@ -1,11 +1,11 @@
-# Configure Satellite Routers with DHCP
+# Configure Satellite Routers with DHCP (Iteration 2)
 
-This guide covers how to configure a satellite (secondary) router in your mesh network to receive its IP address via DHCP from the main router, turning it into a "dumb AP" that only bridges traffic.
+This guide covers the **second iteration** of a wireless mesh deployment: converting each satellite (secondary) router so it receives its LAN IP from the main router via DHCP, turning it into a true "dumb AP" that only bridges traffic. WAN and the firewall are also disabled on the satellite.
 
-This guide implements the concept introduced in [Chapter 2 — One Router to Rule Them All](../../../2-Imaginary-Use-Case/2.2-Expanding-Coverage/2.2.4-DHCP-Satellite.md).
+This guide implements the concept introduced in [Chapter 2.2.4 — One Router to Rule Them All](../../../2-Imaginary-Use-Case/2.2-Expanding-Coverage/2.2.4-DHCP-Satellite.md).
 
-!!! info "This guide builds on the Static IP Mesh guide"
-    The [Static IP Mesh guide](../1-Static-IP-Mesh/index.md) has you assign a **static LAN IP** to the secondary router and disable its DHCP server manually. This guide offers an alternative approach: instead of a hard-coded static IP, the satellite requests its address via DHCP from the main router, and you then pin that address with a static lease. You can follow this guide to set up new satellites, or to convert existing satellites from static IP to DHCP.
+!!! info "This is the second iteration of the mesh deployment"
+    This guide is the recommended evolution of the [Static IP Mesh guide (Iteration 1)](../1-Static-IP-Mesh/index.md). In Iteration 1 you assign each satellite a hard-coded static LAN IP and disable its DHCP server manually. Here, the satellite instead requests its address via DHCP from the main router, and you pin that address with a static lease — matching the "one router to rule them all" model from Chapter 2.2.4. Use this guide to upgrade the satellites you configured in Iteration 1, or to set up new satellites directly in this mode.
 
 ## What You'll Learn
 
@@ -43,12 +43,12 @@ After completing this guide:
 1. Go to **Network → Interfaces**.
 2. Find the **LAN** interface and click **Edit**.
 
-![OpenWrt LuCI Interfaces page with LAN interface](images/DHCP-lan-interface-edit.webp){ width="600" }
+    ![OpenWrt LuCI Interfaces page with LAN interface](images/DHCP-lan-interface-edit.webp){ width="600" }
 
 3. In **General Settings**, change **Protocol** to **DHCP client**.
 4. Click **Save** but **do not apply yet**.
 
-![Setting LAN protocol to DHCP client](images/DHCP-set-protocol-dhcp-client.webp){ width="600" }
+    ![Setting LAN protocol to DHCP client](images/DHCP-set-protocol-dhcp-client.webp){ width="600" }
 
 !!! info "Why DHCP client?"
     By setting the satellite's LAN interface to DHCP client mode, it will request an IP address from the main router instead of using a manually configured static IP. This simplifies management and avoids IP conflicts.
@@ -58,15 +58,15 @@ After completing this guide:
 1. Go to **Network → Wireless**.
 2. Review your wireless interfaces.
 
-![Wireless overview showing available interfaces](images/DHCP-wireless-overview.webp){ width="600" }
+    ![Wireless overview showing available interfaces](images/DHCP-wireless-overview.webp){ width="600" }
 
 3. Check the **client-facing WiFi AP** interface — ensure **Network** is set to **lan**.
 
-![WiFi AP interface with Network set to lan](images/DHCP-wifi-ap-network-lan.webp){ width="600" }
+    ![WiFi AP interface with Network set to lan](images/DHCP-wifi-ap-network-lan.webp){ width="600" }
 
 4. Check the **802.11s mesh interface** — ensure **Network** is also set to **lan**.
 
-![Mesh interface with Network set to lan](images/DHCP-mesh-network-lan.webp){ width="600" }
+    ![Mesh interface with Network set to lan](images/DHCP-mesh-network-lan.webp){ width="600" }
 
 !!! info "Why attach to LAN?"
     All wireless interfaces must be bridged to the LAN interface so that traffic from WiFi clients flows through to the main router. If an interface isn't attached to LAN, devices connecting to it won't get internet access.

--- a/docs/3-Guide/Wireless-Mesh/index.md
+++ b/docs/3-Guide/Wireless-Mesh/index.md
@@ -2,54 +2,41 @@
 
 This section covers how to set up an 802.11s wireless mesh network using OpenWrt routers. A mesh network allows multiple routers to communicate wirelessly, extending coverage without running Ethernet cables between buildings or access points.
 
-This section implements the concepts introduced in [Chapter 2.2 — Expanding Coverage](../../2-Imaginary-Use-Case/2.2-Expanding-Coverage/index.md).
+This section implements the concepts introduced in [Chapter 2.2 — Expanding Coverage](../../2-Imaginary-Use-Case/2.2-Expanding-Coverage/index.md), in particular [Wired vs Wireless](../../2-Imaginary-Use-Case/2.2-Expanding-Coverage/2.2.3-Wired-vs-Wireless.md) and [One Router to Rule Them All](../../2-Imaginary-Use-Case/2.2-Expanding-Coverage/2.2.4-DHCP-Satellite.md).
 
-## Two Approaches
+## Recommended path: two iterations
 
-There are two common ways to configure satellite (secondary) routers in your mesh network. Both approaches create a working mesh, but they differ in how you manage IP addresses:
+Do not pick one approach over the other — you start with the simpler one to get the network working, and then evolve it for easier long-term management.
 
-### 1. Static IP Mesh (Manual Assignment)
+### Iteration 1 — Static IP Mesh
 
-In this approach, you manually assign a unique static IP address to each satellite router before connecting it to the mesh. This is straightforward and works well for small deployments where you can easily track which IP belongs to which device.
+Get the mesh working first with the simplest possible setup. Each satellite router is given a unique **static LAN IP** by hand, its local DHCP server is disabled, and the 802.11s mesh backhaul plus a shared 2.4 GHz access point are brought up.
 
-**When to use:**
+This is the fastest way to confirm that the mesh links form, that satellites bridge traffic correctly, and that clients roam between access points. It is the **recommended starting point for every deployment**.
 
-- Small networks with few satellites (2–5 routers)
-- Quick initial testing and prototyping
-- Situations where you want full control over IP assignments from the start
+[Go to Iteration 1 — Static IP Mesh](1-Static-IP-Mesh/index.md)
 
-[Go to Static IP Mesh Guide](1-Static-IP-Mesh/index.md)
+### Iteration 2 — DHCP-based Mesh
 
-### 2. DHCP-Based Mesh (Automatic Assignment)
+Once Iteration 1 is up and running, upgrade each satellite so it gets its LAN IP from the **main router via DHCP**, pinned with a static lease. At the same time, you disable WAN and the firewall on the satellites so they become true "dumb APs" that only bridge traffic.
 
-In this approach, satellites request their IP address from the main router via DHCP, just like any other client device. You then create a static DHCP lease on the main router to ensure the satellite always receives the same IP.
+This iteration centralizes IP management on the main router, makes onboarding new satellites easier, and matches the "one router to rule them all" model from Chapter 2.2.4. It is the **recommended target state** for any deployment that is going to grow or be maintained over time.
 
-**When to use:**
+[Go to Iteration 2 — DHCP-based Mesh](2-DHCP-Mesh/index.md)
 
-- Larger networks with many satellites
-- When you want centralized IP management from the main router
-- When adding new satellites frequently (easier onboarding)
+!!! tip "Start with Iteration 1, then move to Iteration 2"
+    Always begin with the Static IP Mesh guide. Once the mesh is stable and clients can roam, follow the DHCP-based Mesh guide to centralize IP management. The DHCP guide is written to work both for new satellites and for converting the satellites you already configured in Iteration 1.
 
-[Go to DHCP-Based Mesh Guide](2-DHCP-Mesh/index.md)
+!!! info "Can I stop after Iteration 1?"
+    For very small or temporary deployments (2–3 routers, no plan to grow), Iteration 1 is enough. For everything else, plan to do both — the second iteration removes a whole class of long-term operational problems.
 
-## Which Should You Choose?
+## What both iterations cover
 
-| Factor | Static IP | DHCP-Based |
-|--------|-----------|------------|
-| Setup complexity | Simpler initial config | Slightly more steps |
-| IP management | Distributed (on each device) | Centralized (main router) |
-| Adding new satellites | Manual IP planning | Automatic, then pin with lease |
-| Troubleshooting | IP always known | Must check DHCP leases |
-| Best for | Small, stable networks | Growing, dynamic networks |
+Across both iterations, the guides walk you through:
 
-!!! tip "Start with Static; migrate to DHCP later"
-    If you're new to mesh networking, start with the **Static IP Mesh** guide to get your network running quickly. Once you're comfortable, you can migrate satellites to the **DHCP-Based** approach for easier long-term management — the [DHCP guide](2-DHCP-Mesh/index.md) explains how to convert existing satellites.
+- Replacing the default Wi-Fi package with the mesh-capable `wpad-mesh-wolfssl`.
+- Creating a 5 GHz 802.11s mesh backhaul between routers.
+- Configuring a shared 2.4 GHz access point so clients roam seamlessly.
+- Ensuring only the main router runs DHCP, so satellites never compete with it.
 
-## Common to Both Approaches
-
-Regardless of which IP assignment method you choose, both guides cover:
-
-- Replacing the default Wi-Fi package with the mesh-capable `wpad-mesh-wolfssl`
-- Creating a 5 GHz 802.11s mesh backhaul between routers
-- Configuring a shared 2.4 GHz access point for end users
-- Disabling DHCP server on satellites to avoid conflicts
+The difference is **how the satellite gets its own management IP**: hard-coded in Iteration 1, assigned by the main router (and pinned with a static lease) in Iteration 2.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,8 +89,8 @@ nav:
       - 3-Guide/IP-Addressing/index.md
     - Wireless Mesh:
       - 3-Guide/Wireless-Mesh/index.md
-      - Static IP Mesh: 3-Guide/Wireless-Mesh/1-Static-IP-Mesh/index.md
-      - DHCP-Based Mesh: 3-Guide/Wireless-Mesh/2-DHCP-Mesh/index.md
+      - Iteration 1 — Static IP Mesh: 3-Guide/Wireless-Mesh/1-Static-IP-Mesh/index.md
+      - Iteration 2 — DHCP-based Mesh: 3-Guide/Wireless-Mesh/2-DHCP-Mesh/index.md
     - Nextcloud:
       - 3-Guide/Nextcloud/index.md
     - OpenWISP:


### PR DESCRIPTION
Summary --- Open points listed on the pinned message Telegram.
This PR restructures the Wireless Mesh guides from two alternative approaches into a sequential two-iteration learning path — Iteration 1 (Static IP) followed by Iteration 2 (DHCP-based). The changes clarify the recommended workflow for deployers, making it clearer when to stop after Iteration 1 and when to proceed to Iteration 2.

Changes
- Wireless Mesh overview (index.md) — Reframed as a recommended path with two iterations, adding clear guidance on when each iteration is appropriate and what both cover
- Iteration 1 — Static IP Mesh — Updated title, added iteration context, expanded cross-references to Chapter 2.2.3, reformatted steps to numbered instruction format, and added a critical step to use "Apply Unchecked" to prevent settings rollback
- Iteration 2 — DHCP-based Mesh — Updated title and clarified that this is the second iteration, with clearer chaining from Iteration 1
- mkdocs.yml — Updated navigation labels to reflect iteration naming

Adding better numbering for each steps in the chapter 3-Guide/1-Static-IP-Mesh/index.md